### PR TITLE
Fix check of parameters in setalarm

### DIFF
--- a/src/bridge.js
+++ b/src/bridge.js
@@ -271,11 +271,11 @@ async function listAlarms () {
   return devices[0].AlarmList().then(alarms => {
     log.debug('Got alarms %j', alarms)
     mqttClient.publish(config.name + '/alarms', JSON.stringify(alarms), { retain: false })
+    return true
   })
 }
 async function setalarm (payload) {
-  payload = ConvertToObjectIfPossible(payload)
-  if (payload.id && payload.enabled) {
+  if (payload.id !== null && payload.enabled !== null) {
     return devices[0].AlarmPatch({ ID: payload.id, Enabled: payload.enabled === true })
   }
 }


### PR DESCRIPTION
Publishing a message to `sonos/cmd/setalarm` lead to

`
2020-01-18 12:53:34.046 <debug> Error parsing json SyntaxError: Unexpected token o in JSON at position 1
    at JSON.parse (<anonymous>)
    at ConvertToObjectIfPossible (/Users/swerner/Documents/src/sonos2mqtt/src/bridge.js:401:17)
    at setalarm (/Users/swerner/Documents/src/sonos2mqtt/src/bridge.js:277:13)
    at handleGenericCommand (/Users/swerner/Documents/src/sonos2mqtt/src/bridge.js:255:14)
    at MqttClient.handleIncomingMessage (/Users/swerner/Documents/src/sonos2mqtt/src/bridge.js:113:12)
    at MqttClient.emit (events.js:223:5)
    at MqttClient._handlePublish (/Users/swerner/Documents/src/sonos2mqtt/node_modules/mqtt/lib/client.js:1162:12)
    at MqttClient._handlePacket (/Users/swerner/Documents/src/sonos2mqtt/node_modules/mqtt/lib/client.js:351:12)
    at work (/Users/swerner/Documents/src/sonos2mqtt/node_modules/mqtt/lib/client.js:283:12)
    at Writable.writable._write (/Users/swerner/Documents/src/sonos2mqtt/node_modules/mqtt/lib/client.js:294:5)
`

This was due to a double conversion of the supplied payload into an object. `ConvertToObjectIfPossible(payload)` was called in `handleGenericCommand()` and in `setalarm()` additionally. 

I also fixed the check for supplied parameters in `setalarm()`. The check didn't allow to set an alarm to false before. 