### PR TITLE
Add Github action for buildung docker images

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,8 @@
 name: buildx
 
 on:
-  push:
-    branches: master
-    tags:
+  release:
+    types: [published]
 
 jobs:
   buildx:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,5 +30,6 @@ jobs:
           docker buildx build \
             --platform linux/386,linux/amd64,linux/arm/v7,linux/arm64 \
             --push \
-            -t $GITHUB_REPOSITORY \
+            -t $GITHUB_REPOSITORY:latest \
+            -t $GITHUB_REPOSITORY:$GITHUB_REF \
             .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,35 @@
+name: buildx
+
+on:
+  push:
+    branches: master
+    tags:
+
+jobs:
+  buildx:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v1
+      -
+        name: Set up Docker Buildx
+        id: buildx
+        uses: crazy-max/ghaction-docker-buildx@v1
+        with:
+          version: latest
+      -
+        name: Available platforms
+        run: echo ${{ steps.buildx.outputs.platforms }}
+      -
+        name: Docker login
+        run:
+          docker login -u ${{ secrets.REGISTRY_USERNAME }} -p ${{ secrets.REGISTRY_PASSWORD }}
+      -
+        name: Run Buildx
+        run: |
+          docker buildx build \
+            --platform linux/386,linux/amd64,linux/arm/v7,linux/arm64 \
+            --push \
+            -t $GITHUB_REPOSITORY \
+            .


### PR DESCRIPTION
Here's the PR that adds the Github action (#49). The action builds images for 4 architectures and pushes them to the docker hub.

You have to add two Github secrets: REGISTRY_USERNAME and REGISTRY_PASSWORD
See here for reference: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets

I suggest that you create an Access Token on the docker hub. The access token can be used as password for the registry. The tokens can be created in the Account Setting on docker hub. You find the function on the security section.

Please review everything and report what to change if necessary.
