### PR TITLE
Fix tagging of docker image for releases

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,9 +1,8 @@
 name: Docker build and push
 
 on:
-  push:
-    branches: 
-      - master
+  release:
+    types: [published]
 
 jobs:
   buildx:
@@ -32,4 +31,5 @@ jobs:
             --platform linux/386,linux/amd64,linux/arm/v7,linux/arm64 \
             --push \
             -t $GITHUB_REPOSITORY:latest \
+            -t $GITHUB_REPOSITORY:$(echo $GITHUB_REF | cut -d'/' -f3) \
             .


### PR DESCRIPTION
I saw we had trouble with building our first docker image. This was due to content of the environment variable $GITHUB_REF. It contains a complete git ref (e.g. `refs/tags/v2.0.7`).

The PR contains a solution by cutting the refs string on `/` only selection the third result: the tag name. I initially tested this workaround but removed it in the final PR because I misinterpreted the Github documentation (https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#release-event-release). I expected the variable will only contain the tag name.

Maybe you want to give this version of the action a new try for the next release. If you only change the tagging parameter in the build step and leave the on trigger as it is the generated images will be tagged with the branch name (maybe useful for testing if the action now works as expected).